### PR TITLE
added odom_mileage to scitos_bringup

### DIFF
--- a/scitos_bringup/launch/scitos.launch
+++ b/scitos_bringup/launch/scitos.launch
@@ -31,6 +31,9 @@
 	<!--- Robot state publisher -->
 	<include file="$(find scitos_description)/launch/scitos_state_publisher.launch"/>
 
+        <!-- Odom Mileage -->
+        <node name="odometry_mileage" pkg="odometry_mileage" type="odometry_mileage" />	
+	
 	<!-- PC Monitor -->
 	<node name="pc_monitor" pkg="scitos_pc_monitor" type="pc_monitor.py" />
 


### PR DESCRIPTION
I'm not aware of odom_mileage being launched anywhere, I think we should just keep it as a standard node to be launched everytime. If this is accepted I call for a marathon rematch :)
