### PR TITLE
[openni_wrapper] Using right environment to launch cameras on different machines.

### DIFF
--- a/openni_wrapper/launch/main.launch
+++ b/openni_wrapper/launch/main.launch
@@ -5,7 +5,7 @@
   <arg name="user"   	default="" />
   <arg name="publish_tf" default="false" />
  
-  <machine name="$(arg machine)" address="$(arg machine)" env-loader="/opt/ros/hydro/env.sh" user="$(arg user)"/>
+  <machine name="$(arg machine)" address="$(arg machine)" env-loader="/opt/strands/strands_catkin_ws/devel/env.sh" user="$(arg user)"/>
 
   <!-- Load reasonable defaults for the relative pose between cameras -->
   <include if="$(arg publish_tf)"


### PR DESCRIPTION
This assumes that everyone followed the install instructions and installed everything to `/opt/strands/strands_catkin_ws`
After this has been merged you can run the chest camera on a different pc with something like:

```
ROSLAUNCH_SSH_UNKNOWN=1 ROS_MASTER_URI=http://linda:11311 roslaunch openni_wrapper main.launch machine:=left-cortex user:=strands camera:=chest_xtion
```

Replacing the linda specific master uri and machine name.
