### PR TITLE
scitos prefix removed for door_pass and ramp_climb

### DIFF
--- a/scitos_bringup/launch/strands_navigation.launch
+++ b/scitos_bringup/launch/strands_navigation.launch
@@ -46,7 +46,7 @@
 
 
 	<!--- Ramp Climbing -->
-    <include file="$(find scitos_ramp_climb)/launch/rampclimbing_mux.launch">
+    <include file="$(find ramp_climb)/launch/rampclimbing_mux.launch">
 	    <arg name="machine"  value="$(arg machine)"/>
 	    <arg name="user"  value="$(arg user)"/>
 	</include>

--- a/scitos_bringup/launch/strands_navigation.launch
+++ b/scitos_bringup/launch/strands_navigation.launch
@@ -39,7 +39,7 @@
 
 
 	<!--- Door Passing -->
-    <include file="$(find scitos_door_pass)/launch/doorpassing_mux.launch">
+    <include file="$(find door_pass)/launch/doorpassing_mux.launch">
 	    <arg name="machine"  value="$(arg machine)"/>
 	    <arg name="user"  value="$(arg user)"/>
 	</include>


### PR DESCRIPTION
Needs https://github.com/strands-project/strands_apps/pull/3 merged.
